### PR TITLE
🧹 Janitor: Fix Prettier deprecated pluginSearchDirs option

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-01: Removed deprecated `pluginSearchDirs` and `--plugin-search-dir` from Prettier configuration and scripts.

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,5 @@
 	"trailingComma": "none",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte"],
-	"pluginSearchDirs": ["."],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@ run = "bun run svelte-kit sync"
 depends = ["install"]
 
 [tasks."lint:prettier"]
-run = "bun run prettier --plugin-search-dir . --check ."
+run = "bun run prettier --check ."
 depends = ["install"]
 
 [tasks."lint:eslint"]
@@ -24,7 +24,7 @@ depends = ["install", "codegen"]
 depends = ["lint:*"]
 
 [tasks."fmt:prettier"]
-run = "bun run prettier --plugin-search-dir . --write ."
+run = "bun run prettier --write ."
 depends = ["install"]
 
 [tasks.fmt]

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest",
-		"lint": "prettier --plugin-search-dir . --check . && eslint .",
-		"format": "prettier --plugin-search-dir . --write ."
+		"lint": "prettier --check . && eslint .",
+		"format": "prettier --write ."
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.0",


### PR DESCRIPTION
**What Changed**
- Removed deprecated `pluginSearchDirs` from `.prettierrc`.
- Removed deprecated `--plugin-search-dir .` from `mise.toml` tasks `lint:prettier` and `fmt:prettier`.
- Added a journal entry in `.jules/janitor.md` following the required format.

**Why This Helps**
Prettier configuration warnings for `pluginSearchDirs` being deprecated were polluting the lint output. Removing them cleans up the output and uses modern Prettier configuration correctly.

**Before/After**
- Before: Running `mise run lint:prettier` output warnings like `[warn] Ignored unknown option { pluginSearchDirs: ["."] }.`.
- After: Running `mise run lint:prettier` executes without warnings.

**Verification**
- Verified using `mise run lint` and `mise run fmt`, making sure there are no new warnings.
- Verified test suite passes via `mise run ci`.

**Assumptions**
- Assumed `prettier-plugin-svelte` in `.prettierrc` `plugins` list is sufficient for the plugin discovery without the deprecated search dirs flag.

**Alternatives Not Chosen**
- Keeping the warnings. This conflicts with the Janitor's goal of fixing linters.

**How To Pivot**
- Revert the changes to `.prettierrc` and `mise.toml` to restore the original state if needed, though they will trigger warnings.

**Next Knobs**
- Update or migrate other linter configurations in `eslint.config.js` or `svelte.config.js` if necessary.

---
*PR created automatically by Jules for task [2895123267446661470](https://jules.google.com/task/2895123267446661470) started by @lucasew*